### PR TITLE
Changed Rickroll link to one without ads

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -35,7 +35,7 @@
     <header>
         <div class="left" id="hey">Heyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy</div>
         <nav class="right">
-            <a class="accent block" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">Reserve now</a>
+            <a class="accent block" href="https://www.youtube.com/watch?v=oHg5SJYRHA0" target="_blank">Reserve now</a>
         </nav>
     </header>
 
@@ -46,7 +46,7 @@
             Disrupt your unremarkable gmail.com's and harvard.edu's.
             <span class="accent">heyyyyyyyyyyyy.com</span> emails <em>stand out.</em>
             </p>
-            <a class="cta cta-big accent block" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">Reserve now 👉</a>
+            <a class="cta cta-big accent block" href="https://www.youtube.com/watch?v=oHg5SJYRHA0" target="_blank">Reserve now 👉</a>
             <p class="count">
             (31/200 left in stock)
             </p>
@@ -97,7 +97,7 @@
                 <br/>
                 - russ h.
             </div>
-            <a class="full-send-btn accent block" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">
+            <a class="full-send-btn accent block" href="https://www.youtube.com/watch?v=oHg5SJYRHA0" target="_blank">
                 Full send 👉
             </a>
         </div>
@@ -188,7 +188,7 @@
         <p>
         Interested? Reach out to <span class="accent">hey@heyyyyyyyyyyyy.com</span> to start our hand-crafted, three-month-long, white-glove onboarding process which comes with a complementary bottle of champagne, a traditional mud massage, a door handle from a vintage Rolls-Royce Phantom, a portrait of a dead European royalty framed in gold, Leonardo Da Vinci's left thumb, and of course, your very own <span class="accent">heyyyyyyyyyyyy.com</span> email.
         </p>
-        <a class="cta cta-big accent block" href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" target="_blank">Reserve now 👉</a>
+        <a class="cta cta-big accent block" href="https://www.youtube.com/watch?v=oHg5SJYRHA0" target="_blank">Reserve now 👉</a>
     </section>
 
     <footer>


### PR DESCRIPTION
I just got rickrolled by https://heyyyyyyyyyyyy.com/, but the rickroll had an ad so I knew that I was about to get rickrolled. I switched out the rickroll to being one without ads (https://www.youtube.com/watch?v=oHg5SJYRHA0).